### PR TITLE
[FIX] Fixed markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+.idea

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,21 +1,21 @@
 import Ember from 'ember';
 
 export default Ember.ArrayController.extend({
-  zoom: 17,
+  zoom:      17,
   centerLat: 14.7646531,
   centerLng: 102.8115874,
 
-  polyline: Ember.computed('model', function() {
+  polyline: Ember.computed('model', function () {
     return {
-	  path: this.get('model'), 
-	  isEditable: true
-	};
+      path:       this.get('model'),
+      isEditable: true
+    };
   }),
-  
-  polylinesArray: Ember.computed('polyline', function() {
-    return [ this.get('polyline') ];
+
+  polylinesArray: Ember.computed('polyline', function () {
+    return [this.get('polyline')];
   }),
-  
+
   actions: {
     duplicateMarker: function (target) {
       var newMarker, marker;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-	model: function() {
-		return Ember.A([
-	    	{title: "Home", latitude: 14.766127, longitude: 1.810987, body: "Here is my home"},
-	      	{title: "Shop", latitude: 14.762963, longitude: 102.812285, body: "Here is my shop"},
-	      	{title: "Job", latitude: 14.762900, longitude: 102.812018, body: "Here is my job"}
-	   ]);
-	}
+  model: function () {
+    return Ember.A([
+      {title: "Home", latitude: 14.766127, longitude: 1.810987, body: "Here is my home"},
+      {title: "Shop", latitude: 14.762963, longitude: 102.812285, body: "Here is my shop"},
+      {title: "Job", latitude: 14.762900, longitude: 102.812018, body: "Here is my job"}
+    ]);
+  }
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,32 +1,33 @@
-<h2 id="title">Welcome to Google Map whith Ember Cli.</h2>
+<h2 id="title">Welcome to Google Map with Ember Cli.</h2>
 
-{{google-map markerInfoWindowTemplateName='map/info-window'
-			 markers=model
-			 polylines=polylinesArray
-			 markerViewClass='map/marker'
-			 autoFitBounds=true
-			 lat=centerLat
-			 lng=centerLng
-			 zoom=zoom
-			 gopt_zoomControl=false
-			 type='satellite'}}
+{{google-map
+markers=model
+markerController='map/my-marker'
+markerInfoWindowTemplateName='map/info-window'
+markerViewClass='map/marker'
+autoFitBounds=true
+lat=centerLat
+lng=centerLng
+zoom=zoom
+gopt_zoomControl=false
+type='satellite'}}
 
 <div class="controls">
   <div>
-  	Zoom:
+    Zoom:
     {{input type="range" value=zoom min=0 max=18 step=1}}
-	{{zoom}}
+    {{zoom}}
   </div>
   <div>
-	Number of points:
-  	{{polylinesArray.firstObject.path.length}}
+    Number of points:
+    {{polylinesArray.firstObject.path.length}}
   </div>
   <div>
-	Center:
-  	{{centerLat}}, {{centerLng}}
+    Center:
+    {{centerLat}}, {{centerLng}}
   </div>
   <div>
-	Bounds:
-	
+    Bounds:
+
   </div>
 </div>


### PR DESCRIPTION
- auto re-formatted code following `.editorconfig`
- fixed the missing controller specification for markers
- removed the `polylinesArray` from the component call. You'll have to create a model wrapper such as an array proxy so that the items in the path have `lat` and `lng`. My component does not support having an item controller on the `path`, this would be too much processing and slow down the whole thing

I believe what you should do if you plan on using the model for the path of a polyline as well as for each marker is to first wrap make a model definition (`DS.Model` or `Ember.ObjectProxy`) for your data with a CP linking `lat` to `latitude` and `lng` to `longitude`, then in the component you wouldn't have to extend any controller, and it would work for polyline path as well.